### PR TITLE
OS-agnostic unit tests

### DIFF
--- a/src/utils/formatCode.spec.ts
+++ b/src/utils/formatCode.spec.ts
@@ -1,3 +1,4 @@
+import {EOL} from 'os';
 import { formatCode } from './formatCode';
 
 const input1 = `{ foo: true }`;
@@ -13,20 +14,14 @@ foo: true,
 bar: 123
 }`;
 
-const output3 = `{
-\tfoo: true,
-\tbar: 123
-}`;
+const output3 = `{${EOL}\tfoo: true,${EOL}\tbar: 123${EOL}}`;
 
 const input4 = `{
 \t\t\t\tfoo: true,
 \t\t\t\tbar: 123
 }`;
 
-const output4 = `{
-\tfoo: true,
-\tbar: 123
-}`;
+const output4 = `{${EOL}\tfoo: true,${EOL}\tbar: 123${EOL}}`;
 
 describe('format', () => {
     it('should produce correct result', () => {

--- a/src/utils/formatCode.ts
+++ b/src/utils/formatCode.ts
@@ -2,7 +2,7 @@ import { EOL } from 'os';
 
 export const formatCode = (s: string): string => {
     let indent: number = 0;
-    let lines = s.split(EOL);
+    let lines = s.split(/[\r\n]+/);
     lines = lines.map(line => {
         line = line.trim().replace(/^\*/g, ' *');
         let i = indent;

--- a/src/utils/writeClientCore.spec.ts
+++ b/src/utils/writeClientCore.spec.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import { resolve } from 'path';
 
 import type { Client } from '../client/interfaces/Client';
 import { HttpClient } from '../HttpClient';
@@ -40,11 +41,11 @@ describe('writeClientCore', () => {
 
         await writeClientCore(client, templates, '/', HttpClient.FETCH, Indent.SPACE_4);
 
-        expect(writeFile).toBeCalledWith('/OpenAPI.ts', `settings${EOL}`);
-        expect(writeFile).toBeCalledWith('/ApiError.ts', `apiError${EOL}`);
-        expect(writeFile).toBeCalledWith('/ApiRequestOptions.ts', `apiRequestOptions${EOL}`);
-        expect(writeFile).toBeCalledWith('/ApiResult.ts', `apiResult${EOL}`);
-        expect(writeFile).toBeCalledWith('/CancelablePromise.ts', `cancelablePromise${EOL}`);
-        expect(writeFile).toBeCalledWith('/request.ts', `request${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/OpenAPI.ts'), `settings${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/ApiError.ts'), `apiError${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/ApiRequestOptions.ts'), `apiRequestOptions${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/ApiResult.ts'), `apiResult${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/CancelablePromise.ts'), `cancelablePromise${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/request.ts'), `request${EOL}`);
     });
 });

--- a/src/utils/writeClientIndex.spec.ts
+++ b/src/utils/writeClientIndex.spec.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path';
+
 import type { Client } from '../client/interfaces/Client';
 import { writeFile } from './fileSystem';
 import type { Templates } from './registerHandlebarTemplates';
@@ -36,6 +38,6 @@ describe('writeClientIndex', () => {
 
         await writeClientIndex(client, templates, '/', true, true, true, true, true, 'Service', '');
 
-        expect(writeFile).toBeCalledWith('/index.ts', 'index');
+        expect(writeFile).toBeCalledWith(resolve('/', '/index.ts'), 'index');
     });
 });

--- a/src/utils/writeClientModels.spec.ts
+++ b/src/utils/writeClientModels.spec.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import { resolve } from 'path';
 
 import type { Model } from '../client/interfaces/Model';
 import { HttpClient } from '../HttpClient';
@@ -53,6 +54,6 @@ describe('writeClientModels', () => {
 
         await writeClientModels(models, templates, '/', HttpClient.FETCH, false, Indent.SPACE_4);
 
-        expect(writeFile).toBeCalledWith('/User.ts', `model${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/User.ts'), `model${EOL}`);
     });
 });

--- a/src/utils/writeClientSchemas.spec.ts
+++ b/src/utils/writeClientSchemas.spec.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import { resolve } from 'path';
 
 import type { Model } from '../client/interfaces/Model';
 import { HttpClient } from '../HttpClient';
@@ -53,6 +54,6 @@ describe('writeClientSchemas', () => {
 
         await writeClientSchemas(models, templates, '/', HttpClient.FETCH, false, Indent.SPACE_4);
 
-        expect(writeFile).toBeCalledWith('/$User.ts', `schema${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/$User.ts'), `schema${EOL}`);
     });
 });

--- a/src/utils/writeClientServices.spec.ts
+++ b/src/utils/writeClientServices.spec.ts
@@ -1,4 +1,5 @@
 import { EOL } from 'os';
+import { resolve } from 'path';
 
 import type { Service } from '../client/interfaces/Service';
 import { HttpClient } from '../HttpClient';
@@ -41,6 +42,6 @@ describe('writeClientServices', () => {
 
         await writeClientServices(services, templates, '/', HttpClient.FETCH, false, false, Indent.SPACE_4, 'Service');
 
-        expect(writeFile).toBeCalledWith('/UserService.ts', `service${EOL}`);
+        expect(writeFile).toBeCalledWith(resolve('/', '/UserService.ts'), `service${EOL}`);
     });
 });


### PR DESCRIPTION
File system and code format tests should now pass on all systems. Previously, expected test results did not match on Windows systems due to their differences in line endings and path encoding. See commit messages for more details.