### PR TITLE
Add support for apiKeys security schemes

### DIFF
--- a/src/client/interfaces/ApiKeyScheme.ts
+++ b/src/client/interfaces/ApiKeyScheme.ts
@@ -1,4 +1,4 @@
-export interface OperationApiKey {
+export interface ApiKeyScheme {
     key: string;
     name: string;
     in: 'header' | 'query' | 'cookie';

--- a/src/client/interfaces/Client.d.ts
+++ b/src/client/interfaces/Client.d.ts
@@ -1,9 +1,11 @@
 import type { Model } from './Model';
 import type { Service } from './Service';
+import type { ApiKeyScheme } from "./ApiKeyScheme";
 
 export interface Client {
     version: string;
     server: string;
     models: Model[];
     services: Service[];
+    apiKeys?: ApiKeyScheme[];
 }

--- a/src/client/interfaces/Operation.d.ts
+++ b/src/client/interfaces/Operation.d.ts
@@ -1,6 +1,7 @@
 import type { OperationError } from './OperationError';
 import type { OperationParameters } from './OperationParameters';
 import type { OperationResponse } from './OperationResponse';
+import type { OperationApiKey } from "./OperationApiKey";
 
 export interface Operation extends OperationParameters {
     service: string;
@@ -14,4 +15,5 @@ export interface Operation extends OperationParameters {
     results: OperationResponse[];
     responseHeader: string | null;
     server?: string;
+    apiKeys?: OperationApiKey[];
 }

--- a/src/client/interfaces/Operation.d.ts
+++ b/src/client/interfaces/Operation.d.ts
@@ -1,7 +1,7 @@
 import type { OperationError } from './OperationError';
 import type { OperationParameters } from './OperationParameters';
 import type { OperationResponse } from './OperationResponse';
-import type { OperationApiKey } from "./OperationApiKey";
+import type { ApiKeyScheme } from "./ApiKeyScheme";
 
 export interface Operation extends OperationParameters {
     service: string;
@@ -15,5 +15,5 @@ export interface Operation extends OperationParameters {
     results: OperationResponse[];
     responseHeader: string | null;
     server?: string;
-    apiKeys?: OperationApiKey[];
+    apiKeys?: ApiKeyScheme[];
 }

--- a/src/client/interfaces/OperationApiKey.ts
+++ b/src/client/interfaces/OperationApiKey.ts
@@ -1,0 +1,5 @@
+export interface OperationApiKey {
+    key: string;
+    name: string;
+    in: 'header' | 'query' | 'cookie';
+}

--- a/src/openApi/v2/index.ts
+++ b/src/openApi/v2/index.ts
@@ -4,6 +4,7 @@ import { getModels } from './parser/getModels';
 import { getServer } from './parser/getServer';
 import { getServices } from './parser/getServices';
 import { getServiceVersion } from './parser/getServiceVersion';
+import { ApiKeyScheme } from "../../client/interfaces/ApiKeyScheme";
 
 /**
  * Parse the OpenAPI specification to a Client model that contains
@@ -15,6 +16,7 @@ export const parse = (openApi: OpenApi): Client => {
     const server = getServer(openApi);
     const models = getModels(openApi);
     const services = getServices(openApi);
+    const apiKeys = openApi.securityDefinitions ? Object.entries(openApi.securityDefinitions).filter(([_, scheme]) => scheme.type === 'apiKey').map(([key, scheme]) => ({ key, name: scheme.name, in: scheme.in } as ApiKeyScheme)) : undefined;
 
-    return { version, server, models, services };
+    return { version, server, models, services, apiKeys };
 };

--- a/src/openApi/v2/parser/getOperation.ts
+++ b/src/openApi/v2/parser/getOperation.ts
@@ -10,6 +10,7 @@ import { getOperationResponses } from './getOperationResponses';
 import { getOperationResults } from './getOperationResults';
 import { getServiceName } from './getServiceName';
 import { sortByRequired } from './sortByRequired';
+import { getOperationApiKeys } from "./getOperationApiKeys";
 
 export const getOperation = (
     openApi: OpenApi,
@@ -21,6 +22,7 @@ export const getOperation = (
 ): Operation => {
     const serviceName = getServiceName(tag);
     const operationName = getOperationName(url, method, op.operationId);
+    const apiKeys = getOperationApiKeys(openApi, op);
 
     // Create a new operation object for this method.
     const operation: Operation = {
@@ -31,6 +33,7 @@ export const getOperation = (
         deprecated: op.deprecated === true,
         method: method.toUpperCase(),
         path: url,
+        apiKeys: apiKeys,
         parameters: [...pathParams.parameters],
         parametersPath: [...pathParams.parametersPath],
         parametersQuery: [...pathParams.parametersQuery],

--- a/src/openApi/v2/parser/getOperationApiKeys.ts
+++ b/src/openApi/v2/parser/getOperationApiKeys.ts
@@ -1,8 +1,8 @@
 import { OpenApi } from "../interfaces/OpenApi";
 import { OpenApiOperation } from "../interfaces/OpenApiOperation";
-import { OperationApiKey } from "../../../client/interfaces/OperationApiKey";
+import { ApiKeyScheme } from "../../../client/interfaces/ApiKeyScheme";
 
-export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): OperationApiKey[] | undefined => {
+export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): ApiKeyScheme[] | undefined => {
     //  Check op.security and openApi.security for any apiKey requirements.
     //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
     //  Return the OperationApiKeys object.
@@ -14,7 +14,7 @@ export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): Ope
         return undefined;
 
     //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
-    const apiKeys: OperationApiKey[] = [];
+    const apiKeys: ApiKeyScheme[] = [];
     for (const securityRequirement of securityRequirements) {
         for (const securitySchemeName in securityRequirement) {
             if(!openApi.securityDefinitions?.hasOwnProperty(securitySchemeName))

--- a/src/openApi/v2/parser/getOperationApiKeys.ts
+++ b/src/openApi/v2/parser/getOperationApiKeys.ts
@@ -1,0 +1,36 @@
+import { OpenApi } from "../interfaces/OpenApi";
+import { OpenApiOperation } from "../interfaces/OpenApiOperation";
+import { OperationApiKey } from "../../../client/interfaces/OperationApiKey";
+
+export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): OperationApiKey[] | undefined => {
+    //  Check op.security and openApi.security for any apiKey requirements.
+    //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
+    //  Return the OperationApiKeys object.
+    //  If no apiKey requirements are found, return undefined.
+
+    //  Check op.security and openApi.security for any apiKey requirements.
+    const securityRequirements = op.security ?? openApi.security;
+    if (!securityRequirements)
+        return undefined;
+
+    //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
+    const apiKeys: OperationApiKey[] = [];
+    for (const securityRequirement of securityRequirements) {
+        for (const securitySchemeName in securityRequirement) {
+            if(!openApi.securityDefinitions?.hasOwnProperty(securitySchemeName))
+                continue;
+
+            const securityScheme = openApi.securityDefinitions[securitySchemeName];
+            if (!securityScheme || securityScheme.type !== 'apiKey')
+                continue;
+
+            apiKeys.push({
+                key: securitySchemeName,
+                name: securityScheme.name ?? 'X-API-Key',
+                in: securityScheme.in ?? 'header',
+            });
+        }
+    }
+
+    return apiKeys;
+}

--- a/src/openApi/v3/index.ts
+++ b/src/openApi/v3/index.ts
@@ -4,6 +4,8 @@ import { getModels } from './parser/getModels';
 import { getServer } from './parser/getServer';
 import { getServices } from './parser/getServices';
 import { getServiceVersion } from './parser/getServiceVersion';
+import { OpenApiSecurityScheme } from "./interfaces/OpenApiSecurityScheme";
+import { ApiKeyScheme } from "../../client/interfaces/ApiKeyScheme";
 
 /**
  * Parse the OpenAPI specification to a Client model that contains
@@ -15,6 +17,7 @@ export const parse = (openApi: OpenApi): Client => {
     const server = getServer(openApi);
     const models = getModels(openApi);
     const services = getServices(openApi);
+    const apiKeys = openApi.components?.securitySchemes ? Object.entries(openApi.components.securitySchemes).filter(([_, scheme]) => scheme.type === 'apiKey').map(([key, scheme]) => ({ key, name: scheme.name, in: scheme.in } as ApiKeyScheme)) : undefined;
 
-    return { version, server, models, services };
+    return { version, server, models, services, apiKeys };
 };

--- a/src/openApi/v3/interfaces/OpenApiSecurityRequirement.d.ts
+++ b/src/openApi/v3/interfaces/OpenApiSecurityRequirement.d.ts
@@ -2,5 +2,5 @@
  * https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#securityRequirementObject
  */
 export interface OpenApiSecurityRequirement {
-    [name: string]: string;
+    [name: string]: Array<string>;
 }

--- a/src/openApi/v3/parser/getOperation.ts
+++ b/src/openApi/v3/parser/getOperation.ts
@@ -14,6 +14,7 @@ import { getOperationServer } from './getServer';
 import { getRef } from './getRef';
 import { getServiceName } from './getServiceName';
 import { sortByRequired } from './sortByRequired';
+import { getOperationApiKeys } from "./getOperationApiKeys";
 
 export const getOperation = (
     openApi: OpenApi,
@@ -26,6 +27,7 @@ export const getOperation = (
     const serviceName = getServiceName(tag);
     const operationName = getOperationName(url, method, op.operationId);
     const server = getOperationServer(op);
+    const apiKeys = getOperationApiKeys(openApi, op);
 
     // Create a new operation object for this method.
     const operation: Operation = {
@@ -37,6 +39,7 @@ export const getOperation = (
         method: method.toUpperCase(),
         path: url,
         server: server,
+        apiKeys: apiKeys,
         parameters: [...pathParams.parameters],
         parametersPath: [...pathParams.parametersPath],
         parametersQuery: [...pathParams.parametersQuery],

--- a/src/openApi/v3/parser/getOperationApiKeys.ts
+++ b/src/openApi/v3/parser/getOperationApiKeys.ts
@@ -1,8 +1,8 @@
 import { OpenApi } from "../interfaces/OpenApi";
 import { OpenApiOperation } from "../interfaces/OpenApiOperation";
-import { OperationApiKey } from "../../../client/interfaces/OperationApiKey";
+import { ApiKeyScheme } from "../../../client/interfaces/ApiKeyScheme";
 
-export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): OperationApiKey[] | undefined => {
+export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): ApiKeyScheme[] | undefined => {
     //  Check op.security and openApi.security for any apiKey requirements.
     //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
     //  Return the OperationApiKeys object.
@@ -14,7 +14,7 @@ export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): Ope
         return undefined;
 
     //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
-    const apiKeys: OperationApiKey[] = [];
+    const apiKeys: ApiKeyScheme[] = [];
     for (const securityRequirement of securityRequirements) {
         for (const securitySchemeName in securityRequirement) {
             if(!openApi.components?.securitySchemes?.hasOwnProperty(securitySchemeName))

--- a/src/openApi/v3/parser/getOperationApiKeys.ts
+++ b/src/openApi/v3/parser/getOperationApiKeys.ts
@@ -1,0 +1,36 @@
+import { OpenApi } from "../interfaces/OpenApi";
+import { OpenApiOperation } from "../interfaces/OpenApiOperation";
+import { OperationApiKey } from "../../../client/interfaces/OperationApiKey";
+
+export const getOperationApiKeys = (openApi: OpenApi, op: OpenApiOperation): OperationApiKey[] | undefined => {
+    //  Check op.security and openApi.security for any apiKey requirements.
+    //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
+    //  Return the OperationApiKeys object.
+    //  If no apiKey requirements are found, return undefined.
+
+    //  Check op.security and openApi.security for any apiKey requirements.
+    const securityRequirements = op.security ?? openApi.security;
+    if (!securityRequirements)
+        return undefined;
+
+    //  Transform the requirements into an OperationApiKeys object, holding the security scheme's name as key and the apiKey's name and location as value.
+    const apiKeys: OperationApiKey[] = [];
+    for (const securityRequirement of securityRequirements) {
+        for (const securitySchemeName in securityRequirement) {
+            if(!openApi.components?.securitySchemes?.hasOwnProperty(securitySchemeName))
+                continue;
+
+            const securityScheme = openApi.components.securitySchemes[securitySchemeName];
+            if (!securityScheme || securityScheme.type !== 'apiKey')
+                continue;
+
+            apiKeys.push({
+                key: securitySchemeName,
+                name: securityScheme.name ?? 'X-API-Key',
+                in: securityScheme.in ?? 'header',
+            });
+        }
+    }
+
+    return apiKeys;
+}

--- a/src/templates/client.hbs
+++ b/src/templates/client.hbs
@@ -35,6 +35,7 @@ import { {{{name}}}{{{@root.postfix}}} } from './services/{{{name}}}{{{@root.pos
 				USERNAME: OpenAPI?.USERNAME,
 				PASSWORD: OpenAPI?.PASSWORD,
 				HEADERS: OpenAPI?.HEADERS,
+				API_KEYS: OpenAPI?.API_KEYS,
 				ENCODE_PATH: OpenAPI?.ENCODE_PATH,
 			} as OpenAPIConfig,
 		},
@@ -69,6 +70,7 @@ export class {{{clientName}}} {
 			USERNAME: config?.USERNAME,
 			PASSWORD: config?.PASSWORD,
 			HEADERS: config?.HEADERS,
+			API_KEYS: config?.API_KEYS,
 			ENCODE_PATH: config?.ENCODE_PATH,
 		});
 

--- a/src/templates/core/ApiRequestOptions.hbs
+++ b/src/templates/core/ApiRequestOptions.hbs
@@ -1,5 +1,10 @@
 {{>header}}
 
+export interface ApiKey {
+	name: string;
+	in: 'header' | 'query' | 'cookie';
+}
+
 export type ApiRequestOptions = {
 	readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
 	readonly url: string;
@@ -10,6 +15,7 @@ export type ApiRequestOptions = {
 	readonly query?: Record<string, any>;
 	readonly formData?: Record<string, any>;
 	readonly body?: any;
+	readonly apiKeys?: Record<string, ApiKey>;
 	readonly mediaType?: string;
 	readonly responseHeader?: string;
 	readonly errors?: Record<number, string>;

--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -29,5 +29,11 @@ export const OpenAPI: OpenAPIConfig = {
 	PASSWORD: undefined,
 	HEADERS: undefined,
 	ENCODE_PATH: undefined,
-	API_KEYS: undefined,
+	{{#if apiKeys}}
+	API_KEYS: {
+	{{#each apiKeys}}
+		'{{{key}}}': undefined,
+	{{/each}}
+	}
+	{{/if}}
 };

--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -4,6 +4,7 @@ import type { ApiRequestOptions } from './ApiRequestOptions';
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
+type ApiKeys = Record<string, string>;
 
 export type OpenAPIConfig = {
 	BASE: string;
@@ -14,6 +15,7 @@ export type OpenAPIConfig = {
 	USERNAME?: string | Resolver<string> | undefined;
 	PASSWORD?: string | Resolver<string> | undefined;
 	HEADERS?: Headers | Resolver<Headers> | undefined;
+    API_KEYS?: ApiKeys | Resolver<ApiKeys> | undefined;
 	ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
@@ -27,4 +29,5 @@ export const OpenAPI: OpenAPIConfig = {
 	PASSWORD: undefined,
 	HEADERS: undefined,
 	ENCODE_PATH: undefined,
+	API_KEYS: undefined,
 };

--- a/src/templates/core/angular/getHeaders.hbs
+++ b/src/templates/core/angular/getHeaders.hbs
@@ -4,6 +4,8 @@ export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): O
 		username: resolve(options, config.USERNAME),
 		password: resolve(options, config.PASSWORD),
 		additionalHeaders: resolve(options, config.HEADERS),
+		apiKeysHeader: getApiKeys(config, options, 'header'),
+		apiKeysCookies: getApiKeys(config, options, 'cookie'),
 	}).pipe(
 		map(({ token, username, password, additionalHeaders }) => {
 			const headers = Object.entries({
@@ -24,6 +26,20 @@ export const getHeaders = (config: OpenAPIConfig, options: ApiRequestOptions): O
 			if (isStringWithValue(username) && isStringWithValue(password)) {
 				const credentials = base64(`${username}:${password}`);
 				headers['Authorization'] = `Basic ${credentials}`;
+			}
+
+			for(const key in apiKeysHeader) {
+				headers[key] = apiKeysHeader[key];
+			}
+
+			const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => `${key}=${value}`).join('; ');
+			if(isStringWithValue(apiKeysCookiesString)) {
+				if(headers['Cookie']) {
+					headers['Cookie'] = `${headers['Cookie']}; ${apiKeysCookiesString}`;
+				}
+				else {
+					headers['Cookie'] = apiKeysCookiesString;
+				}
 			}
 
 			if (options.body) {

--- a/src/templates/core/angular/request.hbs
+++ b/src/templates/core/angular/request.hbs
@@ -29,6 +29,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/base64}}
 
 
+{{>functions/getApiKeys}}
+
+
 {{>functions/getQueryString}}
 
 
@@ -68,7 +71,7 @@ import type { OpenAPIConfig } from './OpenAPI';
  * @throws ApiError
  */
 export const request = <T>(config: OpenAPIConfig, http: HttpClient, options: ApiRequestOptions): Observable<T> => {
-	const url = getUrl(config, options);
+	const url = await getUrl(config, options);
 	const formData = getFormData(options);
 	const body = getRequestBody(options);
 

--- a/src/templates/core/axios/getHeaders.hbs
+++ b/src/templates/core/axios/getHeaders.hbs
@@ -3,7 +3,10 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
-	const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {}
+	const formHeaders = typeof formData?.getHeaders === 'function' && formData?.getHeaders() || {};
+	const apiKeysHeader = await getApiKeys(config, options, 'header');
+	const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+	const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => `${key}=${value}`).join('; ');
 
 	const headers = Object.entries({
 		Accept: 'application/json',
@@ -24,6 +27,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	if (isStringWithValue(username) && isStringWithValue(password)) {
 		const credentials = base64(`${username}:${password}`);
 		headers['Authorization'] = `Basic ${credentials}`;
+	}
+
+	for(const key in apiKeysHeader) {
+		headers[key] = apiKeysHeader[key];
+	}
+
+	if(isStringWithValue(apiKeysCookiesString)) {
+		if(headers['Cookie']) {
+			headers['Cookie'] = `${headers['Cookie']}; ${apiKeysCookiesString}`;
+		}
+		else {
+			headers['Cookie'] = apiKeysCookiesString;
+		}
 	}
 
 	if (options.body) {

--- a/src/templates/core/axios/request.hbs
+++ b/src/templates/core/axios/request.hbs
@@ -32,6 +32,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/base64}}
 
 
+{{>functions/getApiKeys}}
+
+
 {{>functions/getQueryString}}
 
 
@@ -73,7 +76,7 @@ import type { OpenAPIConfig } from './OpenAPI';
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions, axiosClient: AxiosInstance = axios): CancelablePromise<T> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
-			const url = getUrl(config, options);
+			const url = await getUrl(config, options);
 			const formData = getFormData(options);
 			const body = getRequestBody(options);
 			const headers = await getHeaders(config, options, formData);

--- a/src/templates/core/fetch/getHeaders.hbs
+++ b/src/templates/core/fetch/getHeaders.hbs
@@ -3,6 +3,9 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
+    const apiKeysHeader = await getApiKeys(config, options, 'header');
+    const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+    const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => `${key}=${value}`).join('; ');
 
 	const headers = Object.entries({
 		Accept: 'application/json',
@@ -22,6 +25,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	if (isStringWithValue(username) && isStringWithValue(password)) {
 		const credentials = base64(`${username}:${password}`);
 		headers['Authorization'] = `Basic ${credentials}`;
+	}
+
+	for(const key in apiKeysHeader) {
+		headers[key] = apiKeysHeader[key];
+	}
+
+	if(isStringWithValue(apiKeysCookiesString)) {
+		if(headers['Cookie']) {
+			headers['Cookie'] = `${headers['Cookie']}; ${apiKeysCookiesString}`;
+		}
+		else {
+			headers['Cookie'] = apiKeysCookiesString;
+		}
 	}
 
 	if (options.body) {

--- a/src/templates/core/fetch/request.hbs
+++ b/src/templates/core/fetch/request.hbs
@@ -25,6 +25,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/base64}}
 
 
+{{>functions/getApiKeys}}
+
+
 {{>functions/getQueryString}}
 
 
@@ -65,7 +68,7 @@ import type { OpenAPIConfig } from './OpenAPI';
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
-			const url = getUrl(config, options);
+			const url = await getUrl(config, options);
 			const formData = getFormData(options);
 			const body = getRequestBody(options);
 			const headers = await getHeaders(config, options);

--- a/src/templates/core/functions/getApiKeys.hbs
+++ b/src/templates/core/functions/getApiKeys.hbs
@@ -1,0 +1,17 @@
+export const getApiKeys = async (config: OpenAPIConfig, options: ApiRequestOptions, keyIn?: 'query' | 'header' | 'cookie'): Promise<Record<string, string>> => {
+	const apiKeys = await resolve(options, config.API_KEYS);
+	const result: Record<string, string> = {};
+
+	if(options.apiKeys) {
+		Object.entries(options.apiKeys)
+			.filter(([_, value]) => keyIn ? value.in === keyIn : value)
+			.forEach(([key, value]) => {
+				if(apiKeys?.[key])
+					result[value.name] = apiKeys[key];
+				else
+					console.warn(`API key '${key}' missing in API_KEYS configuration! URL: ${options.server || config.BASE}${options.url}`);
+			});
+	}
+
+	return result;
+}

--- a/src/templates/core/functions/getUrl.hbs
+++ b/src/templates/core/functions/getUrl.hbs
@@ -1,18 +1,25 @@
-const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+const getUrl = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<string> => {
 	const encoder = config.ENCODE_PATH || encodeURI;
+    const apiKeys = await getApiKeys(config, options, 'query');
 
 	const path = options.url
 		.replace('{api-version}', config.VERSION)
-		.replace(/{(.*?)}/g, (substring: string, group: string) => {
+        .replace(/{(.*?)}/g, (substring: string, group: string) => {
 			if (options.path?.hasOwnProperty(group)) {
 				return encoder(String(options.path[group]));
 			}
 			return substring;
-		});
+	});
 
-	const url = `${options.server || config.BASE}${path}`;
-	if (options.query) {
-		return `${url}${getQueryString(options.query)}`;
+    const url = `${options.server || config.BASE}${path}`;
+    const query = options.query ?? {};
+
+    for(const key in apiKeys) {
+		query[key] = apiKeys[key];
+	}
+
+	if (Object.keys(query).length > 0) {
+		return `${url}${getQueryString(query)}`;
 	}
 	return url;
 };

--- a/src/templates/core/node/getHeaders.hbs
+++ b/src/templates/core/node/getHeaders.hbs
@@ -3,6 +3,9 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
+    const apiKeysHeader = await getApiKeys(config, options, 'header');
+    const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+    const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => `${key}=${value}`).join('; ');
 
 	const headers = Object.entries({
 		Accept: 'application/json',
@@ -22,6 +25,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	if (isStringWithValue(username) && isStringWithValue(password)) {
 		const credentials = base64(`${username}:${password}`);
 		headers['Authorization'] = `Basic ${credentials}`;
+	}
+
+	for(const key in apiKeysHeader) {
+		headers[key] = apiKeysHeader[key];
+	}
+
+	if(isStringWithValue(apiKeysCookiesString)) {
+		if(headers['Cookie']) {
+			headers['Cookie'] = `${headers['Cookie']}; ${apiKeysCookiesString}`;
+		}
+		else {
+			headers['Cookie'] = apiKeysCookiesString;
+		}
 	}
 
 	if (options.body) {

--- a/src/templates/core/node/request.hbs
+++ b/src/templates/core/node/request.hbs
@@ -30,6 +30,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/base64}}
 
 
+{{>functions/getApiKeys}}
+
+
 {{>functions/getQueryString}}
 
 
@@ -70,7 +73,7 @@ import type { OpenAPIConfig } from './OpenAPI';
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
-			const url = getUrl(config, options);
+			const url = await getUrl(config, options);
 			const formData = getFormData(options);
 			const body = getRequestBody(options);
 			const headers = await getHeaders(config, options);

--- a/src/templates/core/xhr/getHeaders.hbs
+++ b/src/templates/core/xhr/getHeaders.hbs
@@ -3,6 +3,9 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	const username = await resolve(options, config.USERNAME);
 	const password = await resolve(options, config.PASSWORD);
 	const additionalHeaders = await resolve(options, config.HEADERS);
+    const apiKeysHeader = await getApiKeys(config, options, 'header');
+    const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+    const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => `${key}=${value}`).join('; ');
 
 	const headers = Object.entries({
 		Accept: 'application/json',
@@ -22,6 +25,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
 	if (isStringWithValue(username) && isStringWithValue(password)) {
 		const credentials = base64(`${username}:${password}`);
 		headers['Authorization'] = `Basic ${credentials}`;
+	}
+
+	for(const key in apiKeysHeader) {
+		headers[key] = apiKeysHeader[key];
+	}
+
+	if(isStringWithValue(apiKeysCookiesString)) {
+		if(headers['Cookie']) {
+			headers['Cookie'] = `${headers['Cookie']}; ${apiKeysCookiesString}`;
+		}
+		else {
+			headers['Cookie'] = apiKeysCookiesString;
+		}
 	}
 
 	if (options.body) {

--- a/src/templates/core/xhr/request.hbs
+++ b/src/templates/core/xhr/request.hbs
@@ -28,6 +28,9 @@ import type { OpenAPIConfig } from './OpenAPI';
 {{>functions/base64}}
 
 
+{{>functions/getApiKeys}}
+
+
 {{>functions/getQueryString}}
 
 
@@ -68,7 +71,7 @@ import type { OpenAPIConfig } from './OpenAPI';
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
 	return new CancelablePromise(async (resolve, reject, onCancel) => {
 		try {
-			const url = getUrl(config, options);
+			const url = await getUrl(config, options);
 			const formData = getFormData(options);
 			const body = getRequestBody(options);
 			const headers = await getHeaders(config, options);

--- a/src/templates/exportService.hbs
+++ b/src/templates/exportService.hbs
@@ -150,6 +150,16 @@ export class {{{name}}}{{{@root.postfix}}} {
 				{{/each}}
 			},
 			{{/if}}
+			{{#if apiKeys}}
+				apiKeys: {
+					{{#each apiKeys}}
+					'{{{key}}}': {
+						name: '{{{name}}}',
+						in: '{{{in}}}'
+					},
+					{{/each}}
+				},
+			{{/if}}
 		});
 	}
 

--- a/src/utils/registerHandlebarTemplates.ts
+++ b/src/utils/registerHandlebarTemplates.ts
@@ -27,6 +27,7 @@ import fetchRequest from '../templates/core/fetch/request.hbs';
 import fetchSendRequest from '../templates/core/fetch/sendRequest.hbs';
 import functionBase64 from '../templates/core/functions/base64.hbs';
 import functionCatchErrorCodes from '../templates/core/functions/catchErrorCodes.hbs';
+import functionGetApiKeys from '../templates/core/functions/getApiKeys.hbs';
 import functionGetFormData from '../templates/core/functions/getFormData.hbs';
 import functionGetQueryString from '../templates/core/functions/getQueryString.hbs';
 import functionGetUrl from '../templates/core/functions/getUrl.hbs';
@@ -179,6 +180,7 @@ export const registerHandlebarTemplates = (root: {
     Handlebars.registerPartial('functions/isSuccess', Handlebars.template(functionIsSuccess));
     Handlebars.registerPartial('functions/base64', Handlebars.template(functionBase64));
     Handlebars.registerPartial('functions/resolve', Handlebars.template(functionResolve));
+    Handlebars.registerPartial('functions/getApiKeys', Handlebars.template(functionGetApiKeys));
 
     // Specific files for the fetch client implementation
     Handlebars.registerPartial('fetch/getHeaders', Handlebars.template(fetchGetHeaders));

--- a/src/utils/writeClientCore.ts
+++ b/src/utils/writeClientCore.ts
@@ -35,6 +35,7 @@ export const writeClientCore = async (
         httpRequest,
         server: client.server,
         version: client.version,
+        apiKeys: client.apiKeys,
     };
 
     await writeFile(resolve(outputPath, 'OpenAPI.ts'), i(templates.core.settings(context), indent));

--- a/test/__snapshots__/index.spec.ts.snap
+++ b/test/__snapshots__/index.spec.ts.snap
@@ -34,6 +34,11 @@ exports[`v2 should generate: test\\generated\\v2\\core\\ApiRequestOptions.ts 1`]
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+export interface ApiKey {
+    name: string;
+    in: 'header' | 'query' | 'cookie';
+}
+
 export type ApiRequestOptions = {
     readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
     readonly url: string;
@@ -44,6 +49,7 @@ export type ApiRequestOptions = {
     readonly query?: Record<string, any>;
     readonly formData?: Record<string, any>;
     readonly body?: any;
+    readonly apiKeys?: Record<string, ApiKey>;
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
@@ -210,6 +216,7 @@ import type { ApiRequestOptions } from './ApiRequestOptions';
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
+type ApiKeys = Record<string, string>;
 
 export type OpenAPIConfig = {
     BASE: string;
@@ -220,6 +227,7 @@ export type OpenAPIConfig = {
     USERNAME?: string | Resolver<string> | undefined;
     PASSWORD?: string | Resolver<string> | undefined;
     HEADERS?: Headers | Resolver<Headers> | undefined;
+    API_KEYS?: ApiKeys | Resolver<ApiKeys> | undefined;
     ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
@@ -233,6 +241,7 @@ export const OpenAPI: OpenAPIConfig = {
     PASSWORD: undefined,
     HEADERS: undefined,
     ENCODE_PATH: undefined,
+    API_KEYS: undefined,
 };
 "
 `;
@@ -287,6 +296,24 @@ export const base64 = (str: string): string => {
     }
 };
 
+export const getApiKeys = async (config: OpenAPIConfig, options: ApiRequestOptions, keyIn?: 'query' | 'header' | 'cookie'): Promise<Record<string, string>> => {
+    const apiKeys = await resolve(options, config.API_KEYS);
+    const result: Record<string, string> = {};
+
+    if(options.apiKeys) {
+        Object.entries(options.apiKeys)
+            .filter(([_, value]) => keyIn ? value.in === keyIn : value)
+            .forEach(([key, value]) => {
+                if(apiKeys?.[key])
+                    result[value.name] = apiKeys[key];
+                else
+                    console.warn(\`API key '\${key}' missing in API_KEYS configuration! URL: \${options.server || config.BASE}\${options.url}\`);
+            });
+    }
+
+    return result;
+}
+
 export const getQueryString = (params: Record<string, any>): string => {
     const qs: string[] = [];
 
@@ -321,8 +348,9 @@ export const getQueryString = (params: Record<string, any>): string => {
     return '';
 };
 
-const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+const getUrl = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<string> => {
     const encoder = config.ENCODE_PATH || encodeURI;
+    const apiKeys = await getApiKeys(config, options, 'query');
 
     const path = options.url
         .replace('{api-version}', config.VERSION)
@@ -331,11 +359,17 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
                 return encoder(String(options.path[group]));
             }
             return substring;
-        });
+    });
 
     const url = \`\${options.server || config.BASE}\${path}\`;
-    if (options.query) {
-        return \`\${url}\${getQueryString(options.query)}\`;
+    const query = options.query ?? {};
+
+    for(const key in apiKeys) {
+        query[key] = apiKeys[key];
+    }
+
+    if (Object.keys(query).length > 0) {
+        return \`\${url}\${getQueryString(query)}\`;
     }
     return url;
 };
@@ -381,6 +415,9 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
     const username = await resolve(options, config.USERNAME);
     const password = await resolve(options, config.PASSWORD);
     const additionalHeaders = await resolve(options, config.HEADERS);
+    const apiKeysHeader = await getApiKeys(config, options, 'header');
+    const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+    const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => \`\${key}=\${value}\`).join('; ');
 
     const headers = Object.entries({
         Accept: 'application/json',
@@ -400,6 +437,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
     if (isStringWithValue(username) && isStringWithValue(password)) {
         const credentials = base64(\`\${username}:\${password}\`);
         headers['Authorization'] = \`Basic \${credentials}\`;
+    }
+
+    for(const key in apiKeysHeader) {
+        headers[key] = apiKeysHeader[key];
+    }
+
+    if(isStringWithValue(apiKeysCookiesString)) {
+        if(headers['Cookie']) {
+            headers['Cookie'] = \`\${headers['Cookie']}; \${apiKeysCookiesString}\`;
+        }
+        else {
+            headers['Cookie'] = apiKeysCookiesString;
+        }
     }
 
     if (options.body) {
@@ -531,7 +581,7 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
-            const url = getUrl(config, options);
+            const url = await getUrl(config, options);
             const formData = getFormData(options);
             const body = getRequestBody(options);
             const headers = await getHeaders(config, options);
@@ -3128,6 +3178,11 @@ exports[`v3 should generate: test\\generated\\v3\\core\\ApiRequestOptions.ts 1`]
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
+export interface ApiKey {
+    name: string;
+    in: 'header' | 'query' | 'cookie';
+}
+
 export type ApiRequestOptions = {
     readonly method: 'GET' | 'PUT' | 'POST' | 'DELETE' | 'OPTIONS' | 'HEAD' | 'PATCH';
     readonly url: string;
@@ -3138,6 +3193,7 @@ export type ApiRequestOptions = {
     readonly query?: Record<string, any>;
     readonly formData?: Record<string, any>;
     readonly body?: any;
+    readonly apiKeys?: Record<string, ApiKey>;
     readonly mediaType?: string;
     readonly responseHeader?: string;
     readonly errors?: Record<number, string>;
@@ -3304,6 +3360,7 @@ import type { ApiRequestOptions } from './ApiRequestOptions';
 
 type Resolver<T> = (options: ApiRequestOptions) => Promise<T>;
 type Headers = Record<string, string>;
+type ApiKeys = Record<string, string>;
 
 export type OpenAPIConfig = {
     BASE: string;
@@ -3314,6 +3371,7 @@ export type OpenAPIConfig = {
     USERNAME?: string | Resolver<string> | undefined;
     PASSWORD?: string | Resolver<string> | undefined;
     HEADERS?: Headers | Resolver<Headers> | undefined;
+    API_KEYS?: ApiKeys | Resolver<ApiKeys> | undefined;
     ENCODE_PATH?: ((path: string) => string) | undefined;
 };
 
@@ -3327,6 +3385,7 @@ export const OpenAPI: OpenAPIConfig = {
     PASSWORD: undefined,
     HEADERS: undefined,
     ENCODE_PATH: undefined,
+    API_KEYS: undefined,
 };
 "
 `;
@@ -3381,6 +3440,24 @@ export const base64 = (str: string): string => {
     }
 };
 
+export const getApiKeys = async (config: OpenAPIConfig, options: ApiRequestOptions, keyIn?: 'query' | 'header' | 'cookie'): Promise<Record<string, string>> => {
+    const apiKeys = await resolve(options, config.API_KEYS);
+    const result: Record<string, string> = {};
+
+    if(options.apiKeys) {
+        Object.entries(options.apiKeys)
+            .filter(([_, value]) => keyIn ? value.in === keyIn : value)
+            .forEach(([key, value]) => {
+                if(apiKeys?.[key])
+                    result[value.name] = apiKeys[key];
+                else
+                    console.warn(\`API key '\${key}' missing in API_KEYS configuration! URL: \${options.server || config.BASE}\${options.url}\`);
+            });
+    }
+
+    return result;
+}
+
 export const getQueryString = (params: Record<string, any>): string => {
     const qs: string[] = [];
 
@@ -3415,8 +3492,9 @@ export const getQueryString = (params: Record<string, any>): string => {
     return '';
 };
 
-const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
+const getUrl = async (config: OpenAPIConfig, options: ApiRequestOptions): Promise<string> => {
     const encoder = config.ENCODE_PATH || encodeURI;
+    const apiKeys = await getApiKeys(config, options, 'query');
 
     const path = options.url
         .replace('{api-version}', config.VERSION)
@@ -3425,11 +3503,17 @@ const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {
                 return encoder(String(options.path[group]));
             }
             return substring;
-        });
+    });
 
     const url = \`\${options.server || config.BASE}\${path}\`;
-    if (options.query) {
-        return \`\${url}\${getQueryString(options.query)}\`;
+    const query = options.query ?? {};
+
+    for(const key in apiKeys) {
+        query[key] = apiKeys[key];
+    }
+
+    if (Object.keys(query).length > 0) {
+        return \`\${url}\${getQueryString(query)}\`;
     }
     return url;
 };
@@ -3475,6 +3559,9 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
     const username = await resolve(options, config.USERNAME);
     const password = await resolve(options, config.PASSWORD);
     const additionalHeaders = await resolve(options, config.HEADERS);
+    const apiKeysHeader = await getApiKeys(config, options, 'header');
+    const apiKeysCookies = await getApiKeys(config, options, 'cookie');
+    const apiKeysCookiesString = Object.entries(apiKeysCookies).map(([key, value]) => \`\${key}=\${value}\`).join('; ');
 
     const headers = Object.entries({
         Accept: 'application/json',
@@ -3494,6 +3581,19 @@ export const getHeaders = async (config: OpenAPIConfig, options: ApiRequestOptio
     if (isStringWithValue(username) && isStringWithValue(password)) {
         const credentials = base64(\`\${username}:\${password}\`);
         headers['Authorization'] = \`Basic \${credentials}\`;
+    }
+
+    for(const key in apiKeysHeader) {
+        headers[key] = apiKeysHeader[key];
+    }
+
+    if(isStringWithValue(apiKeysCookiesString)) {
+        if(headers['Cookie']) {
+            headers['Cookie'] = \`\${headers['Cookie']}; \${apiKeysCookiesString}\`;
+        }
+        else {
+            headers['Cookie'] = apiKeysCookiesString;
+        }
     }
 
     if (options.body) {
@@ -3625,7 +3725,7 @@ export const catchErrorCodes = (options: ApiRequestOptions, result: ApiResult): 
 export const request = <T>(config: OpenAPIConfig, options: ApiRequestOptions): CancelablePromise<T> => {
     return new CancelablePromise(async (resolve, reject, onCancel) => {
         try {
-            const url = getUrl(config, options);
+            const url = await getUrl(config, options);
             const formData = getFormData(options);
             const body = getRequestBody(options);
             const headers = await getHeaders(config, options);


### PR DESCRIPTION
### Issue
Currently, security schemes (v3) and security definitions (v2) with a type of `apiKey` are ignored by the parser/client, making it necessary to manually modify the client's request behavior after generating to implement support for API keys. This may be relatively straightforward and simple to some extent. However, more complex security requirements would require more complex and/or hacky solutions, which may negatively affect code maintainability.

### Solution
This PR addresses the issue described above by explicitly passing API key requirements to each request as a part of the `ApiRequestOptions`, resolving the required keys and injecting them into the request header and/or query before sending it (similar to the current handling of `http` security schemes). This adds support for API keys `in: header`, `in: query` and `in: cookie` (v3), as well as including multiple API keys (e.g. for App IDs).
To resolve the required API keys, they need to be specified in `OpenAPI.API_KEYS`, which is automatically populated with all `apiKey` security schemes described in the source specification file (and a default value of `undefined`). If a required API key cannot be resolved when sending a request, the client emits a warning message and skips injecting the respective key.

### Remarks
Since `http` security schemes are already supported (at least in a simple way by sending credentials/tokens alongside every request), this PR does not provide general support for security schemes, but explicitly for API keys. This made it necessary to introduce some interfaces especially for API keys, which is not too elegant. A more universal approach to support all possible security schemes and requirements would be good, maybe someone (including myself) will find some time to address this properly.