### PR TITLE
Updated API keys default value

### DIFF
--- a/src/templates/core/OpenAPI.hbs
+++ b/src/templates/core/OpenAPI.hbs
@@ -32,7 +32,7 @@ export const OpenAPI: OpenAPIConfig = {
 	{{#if apiKeys}}
 	API_KEYS: {
 	{{#each apiKeys}}
-		'{{{key}}}': undefined,
+		'{{{key}}}': '',
 	{{/each}}
 	}
 	{{/if}}


### PR DESCRIPTION
Although the `undefined` default value had the advantage of explicitly telling users they need to provide API keys in the `OpenAPI` config, it has been changed to `''` for the sake of being error-free.